### PR TITLE
Better respect of Golang identifiers conventions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
+	github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/ystia/yorc/v4 v4.0.0-M5

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,8 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/satori/go.uuid v1.0.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516 h1:ofR1ZdrNSkiWcMsRrubK9tb2/SlZVWttAfqUjJi6QYc=
+github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516/go.mod h1:Yow6lPLSAXx2ifx470yD/nUe22Dv5vBvxK/UK9UUTVs=
 github.com/sethgrid/pester v0.0.0-20190127155807-68a33a018ad0/go.mod h1:Ad7IjTpvzZO8Fl0vh9AzQ+j/jYZfyp2diGwI8m5q+ns=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/internal/pkg/parser/parser_test.go
+++ b/internal/pkg/parser/parser_test.go
@@ -152,8 +152,8 @@ func TestParser_ParseTypes(t *testing.T) {
 				DerivedFrom: "Root",
 				Fields: []model.Field{
 					{
-						Name:         "ANumber",
-						OriginalName: "a_number",
+						Name:         "X1Number",
+						OriginalName: "1_number",
 						Type:         "float64",
 					},
 					{
@@ -202,11 +202,17 @@ func TestParser_ParseTypes(t *testing.T) {
 						Type:         "[]int",
 					},
 					{
-						Name:         "ValidBool",
-						OriginalName: "valid_bool",
+						Name:         "ValidBoolID",
+						OriginalName: "valid_bool_id",
 						Type:         "bool",
 					},
 				},
+			},
+			{
+				Name:        "JSON",
+				FQDTN:       "tosca.datatypes.json",
+				DerivedFrom: "string",
+				Fields:      []model.Field{},
 			},
 		}, false},
 		{"TestParseIncludeFilters", &Parser{

--- a/internal/pkg/parser/testdata/extratypes.yaml
+++ b/internal/pkg/parser/testdata/extratypes.yaml
@@ -18,9 +18,9 @@ data_types:
         required: false
         entry_schema:
           type: integer
-      valid_bool:
+      valid_bool_id:
         type: boolean
-      a_number:
+      1_number:
         type: float
       another_type:
         type: tosca.datatypes.Credential
@@ -39,4 +39,6 @@ data_types:
       a_scalar_unit_frequency:
         type: scalar-unit.frequency
 
+  tosca.datatypes.json:
+    derived_from: string
 


### PR DESCRIPTION
- identifiers will always start with a letter
- common initialisms are now capitilized

This results in a better linting results